### PR TITLE
Multi thruster instant plume

### DIFF
--- a/pyrpod/RPOD.py
+++ b/pyrpod/RPOD.py
@@ -536,11 +536,13 @@ class RPOD (MissionPlanner):
                             sigma = float(self.config['tv']['sigma'])
                             thruster_metrics = self.vv.thruster_metrics[self.vv.thruster_data[thruster_id]['type'][0]]
                             simple_plume = SimplifiedGasKinetics(norm_distance, theta, thruster_metrics, T_w, sigma)
-                            pressures[i] += simple_plume.get_pressure()
-                            cum_pressures[i] += pressures[i]
+                            pressure = simple_plume.get_pressure()
+                            pressures[i] += pressure
+                            cum_pressures[i] += pressure
 
-                            heat_flux[i] += simple_plume.get_heat_flux()
-                            cum_heat_flux[i] += heat_flux[i]
+                            heat_flux_cur = simple_plume.get_heat_flux()
+                            heat_flux[i] += heat_flux_cur
+                            cum_heat_flux[i] += heat_flux_cur
                         # print("unit plume normal", unit_plume_normal)
  
                         # print("unit distance", unit_distance)

--- a/pyrpod/RPOD.py
+++ b/pyrpod/RPOD.py
@@ -536,10 +536,10 @@ class RPOD (MissionPlanner):
                             sigma = float(self.config['tv']['sigma'])
                             thruster_metrics = self.vv.thruster_metrics[self.vv.thruster_data[thruster_id]['type'][0]]
                             simple_plume = SimplifiedGasKinetics(norm_distance, theta, thruster_metrics, T_w, sigma)
-                            pressures[i] = simple_plume.get_pressure()
+                            pressures[i] += simple_plume.get_pressure()
                             cum_pressures[i] += pressures[i]
 
-                            heat_flux[i] = simple_plume.get_heat_flux()
+                            heat_flux[i] += simple_plume.get_heat_flux()
                             cum_heat_flux[i] += heat_flux[i]
                         # print("unit plume normal", unit_plume_normal)
  


### PR DESCRIPTION
sums instant impingement values over thrusters per firing,

solves extra cumulative counts bug introduced by line above, ensures the cumulative values only account for each impingement reading once, as opposed to extra times.