### PR TITLE
Disabling plots in test_all.py

### DIFF
--- a/tests/test_case_06.py
+++ b/tests/test_case_06.py
@@ -50,7 +50,7 @@ class ThrustEnvelopeChecks(unittest.TestCase):
         mp = MissionPlanner.MissionPlanner(case_dir)
         mp.set_lm(lm)
         mp.read_flight_plan()
-        mp.plot_thrust_envelope()
+        # mp.plot_thrust_envelope()
         
 
 if __name__ == '__main__':

--- a/tests/test_case_07.py
+++ b/tests/test_case_07.py
@@ -53,7 +53,7 @@ class DeltaMassChecks(unittest.TestCase):
         mp.set_lm(lm)
         mp.read_flight_plan()
 
-        mp.plot_delta_m(1885)
+        # mp.plot_delta_m(1885)
         
 
 if __name__ == '__main__':

--- a/tests/test_case_10.py
+++ b/tests/test_case_10.py
@@ -25,8 +25,8 @@ class IsentropicExpansionCheck(unittest.TestCase):
 
         # Plot isentropic expansion curves.
         isen_plume = IsentropicExpansion.IsentropicExpansion()
-        isen_plume.plot_number_density_ratios_vs_radius(M1, M2, gamma, r_star)
-        isen_plume.plot_temp_ratios_vs_radius(M1, M2, gamma, r_star)
+        # isen_plume.plot_number_density_ratios_vs_radius(M1, M2, gamma, r_star)
+        # isen_plume.plot_temp_ratios_vs_radius(M1, M2, gamma, r_star)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_case_11.py
+++ b/tests/test_case_11.py
@@ -39,7 +39,7 @@ class BurnTimeContourChecks(unittest.TestCase):
         mp = MissionPlanner.MissionPlanner(case_dir)
         mp.set_lm(lm)
         mp.read_flight_plan()
-        mp.plot_burn_time_contour(1194)
+        # mp.plot_burn_time_contour(1194)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_case_12.py
+++ b/tests/test_case_12.py
@@ -35,7 +35,7 @@ class DeltaMassContourChecks(unittest.TestCase):
         mp = MissionPlanner.MissionPlanner(case_dir)
         mp.set_lm(lm)
         mp.read_flight_plan()
-        mp.plot_delta_m_contour()
+        # mp.plot_delta_m_contour()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Deprecated plots no longer pop up and halt the test_all.py run process.